### PR TITLE
feat: add TEMP_UNIT env support with validation and tests

### DIFF
--- a/.env
+++ b/.env
@@ -17,9 +17,11 @@ START_TIME=09:00
 # Latest time to allow plug control (e.g. 6:00 PM
 END_TIME=18:00
  
+#Optional: temperature unit for weather API: "fahrenheit" or "celsius"
+TEMP_UNIT=fahrenheit
 
-# Optional thresholds (default values used if not set)
-# in Fahrenheit
+# Optional: thresholds (default values used if not set)
+# in degrees
 TEMP_THRESHOLD=75
 # in percent
 CLOUD_THRESHOLD=50

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Govee Smart Plug Controller
 
 # Configuration
-VERSION=1.2.1
+VERSION=1.3.0
 PLATFORM=linux/amd64
 DOCKER_DIR=./docker
 DOCKERFILE=$(DOCKER_DIR)/Dockerfile

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ LAT=39.8333
 LON=-98.5855
 START_TIME=00:00
 END_TIME=23:59
+TEMP_UNIT=fahrenheit
 TEMP_THRESHOLD=75
 CLOUD_THRESHOLD=50
 CHECK_INTERVAL=15
@@ -84,6 +85,7 @@ services:
       - LON=-98.5855
       - START_TIME=00:00
       - END_TIME=23:59
+      - TEMP_UNIT=fahrenheit
       - TEMP_THRESHOLD=75
       - CLOUD_THRESHOLD=50
       - CHECK_INTERVAL=15
@@ -169,6 +171,7 @@ This returns JSON with your registered devices and their details, including `dev
 | `LON`            | ✅       | Longitude of your location (e.g., `-88.2724`)                               |
 | `START_TIME`     | ❌       | The earliest time of day (in `HH:MM` 24-hour format) to allow plug control. |
 | `END_TIME  `     | ❌       | The latest time of day (in `HH:MM` 24-hour format) to allow plug control.   |
+| `TEMP_UNIT     ` | ❌       | Temperature unit for weather API: "fahrenheit" or "celsius" (default: `fahrenheit`) |
 | `TEMP_THRESHOLD` | ❌       | Temperature in °F above which the plug turns ON (default: `75`)             |
 | `CLOUD_THRESHOLD`| ❌       | Cloud cover percentage below which the plug turns ON (default: `50`)        |
 | `CHECK_INTERVAL` | ❌       | Time between weather checks, in minutes (default: `15`)                     |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,4 +2,4 @@
 # This marks the app directory as a package.
 # You can optionally define shared variables or expose key components here.
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,15 @@ def get_config():
             print(f"Missing required environment variable: {var}")
             sys.exit(1)
 
-    return {
+    # Load config from environment variables
+    TEMP_UNIT = os.getenv("TEMP_UNIT", "fahrenheit").lower()
+
+    # Validate temperature unit
+    if TEMP_UNIT not in ("fahrenheit", "celsius"):
+        logger.error(f"Invalid TEMP_UNIT: {TEMP_UNIT}. Must be 'fahrenheit' or 'celsius'.")
+        sys.exit(1)
+
+    return { 
         "GOVEE_API_KEY": os.getenv("GOVEE_API_KEY"),
         "DEVICE_MAC": os.getenv("DEVICE_MAC"),
         "DEVICE_MODEL": os.getenv("DEVICE_MODEL"),
@@ -18,6 +26,7 @@ def get_config():
         "LON": float(os.getenv("LON")),
         "START_TIME": os.getenv("START_TIME", "00:00"),
         "END_TIME": os.getenv("END_TIME", "23:59"),
+        "TEMP_UNIT": TEMP_UNIT,
         "TEMP_THRESHOLD": float(os.getenv("TEMP_THRESHOLD", 75)),
         "CLOUD_THRESHOLD": float(os.getenv("CLOUD_THRESHOLD", 50)),
         "CHECK_INTERVAL": float(os.getenv("CHECK_INTERVAL", 15)) * 60,

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -7,13 +7,13 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-def fetch_weather(lat, lon):
+def fetch_weather(lat, lon, temp_unit):
     try:
         url = (
             f"https://api.open-meteo.com/v1/forecast"
             f"?latitude={lat}&longitude={lon}"
             f"&current=temperature_2m,cloudcover"
-            f"&temperature_unit=fahrenheit"
+            f"&temperature_unit={temp_unit}"
             f"&timezone=auto"
         )
         response = requests.get(url)
@@ -29,7 +29,7 @@ def run_loop():
     while True:
         now_within_time = is_within_time_window(config["START_TIME"], config["END_TIME"])
         if now_within_time:
-            temp, cloud = fetch_weather(config["LAT"], config["LON"])
+            temp, cloud = fetch_weather(config["LAT"], config["LON"]), config["TEMP_UNIT"]
             if temp is None:
                 time.sleep(config["CHECK_INTERVAL"])
                 continue

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-# Ensure we're in the tests directory
+# Exit if any command fails
+set -e
+
+# Get the script directory and go there
 cd "$(dirname "$0")"
 
-# Go up one level to the project root and run all tests with correct module path
-PYTHONPATH=.. python3 -m pytest .
+# Print current path (for debug)
+echo "Running tests from: $(pwd)"
+
+# Run pytest with correct module resolution
+PYTHONPATH=.. pytest .

--- a/tests/test_tempunit.py
+++ b/tests/test_tempunit.py
@@ -1,0 +1,29 @@
+import pytest
+from app.config import get_config  # Adjust import to match your structure
+
+def set_required_env(monkeypatch):
+    monkeypatch.setenv("GOVEE_API_KEY", "dummy-key")
+    monkeypatch.setenv("DEVICE_MAC", "AA:BB:CC:DD:EE:FF")
+    monkeypatch.setenv("DEVICE_MODEL", "H5083")
+    monkeypatch.setenv("LAT", "44.242")
+    monkeypatch.setenv("LON", "-88.278")
+
+def test_valid_temp_unit_fahrenheit(monkeypatch):
+    set_required_env(monkeypatch)
+    monkeypatch.setenv("TEMP_UNIT", "fahrenheit")
+    config = get_config()
+    assert config["TEMP_UNIT"] == "fahrenheit"
+
+def test_valid_temp_unit_celsius(monkeypatch):
+    set_required_env(monkeypatch)
+    monkeypatch.setenv("TEMP_UNIT", "celsius")
+    config = get_config()
+    assert config["TEMP_UNIT"] == "celsius"
+
+def test_invalid_temp_unit(monkeypatch):
+    import pytest  # <-- see next section
+    set_required_env(monkeypatch)
+    monkeypatch.setenv("TEMP_UNIT", "kelvin")
+    with pytest.raises(SystemExit) as e:
+        get_config()
+    assert e.value.code == 1


### PR DESCRIPTION
- Added TEMP_UNIT environment variable to configure temperature units ("fahrenheit" or "celsius")
- Implemented input validation with fallback to default ("fahrenheit")
- Updated weather fetch logic to use the specified unit
- Added unit tests using monkeypatch to verify behavior for valid and invalid values